### PR TITLE
Add config object with custom regions lists

### DIFF
--- a/aws_regions/config.py
+++ b/aws_regions/config.py
@@ -1,0 +1,34 @@
+import dataclasses
+import yaml
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Config:
+    regions_aws: list = field(default_factory=list)
+    regions_aws_cn: list = field(default_factory=list)
+    regions_aws_us_gov: list = field(default_factory=list)
+
+    @classmethod
+    def load_from_file(cls, filename):
+        with open(filename, 'r') as fh:
+            yaml_data = yaml.safe_load(fh)
+
+        attrs = {}
+        fields = {}
+
+        for f in dataclasses.fields(cls):
+            fields[f.name] = f.type
+
+        for section in yaml_data.keys():
+            for k, v in yaml_data[section].items():
+                attr = f"{section}_{k}"
+                attr_type = fields.get(attr, None)
+                if attr_type:
+                    attrs[attr] = attr_type(v)
+
+        return cls(**attrs)
+
+    def get_custom_regions(self, partition):
+        return getattr(self, f'regions_{partition.replace("-", "_")}')

--- a/python3-aws-regions.spec
+++ b/python3-aws-regions.spec
@@ -27,7 +27,13 @@ BuildRequires:  python-rpm-macros
 BuildRequires:  python3-requests
 BuildRequires:  python3-pytest
 BuildRequires:  python3-vcrpy
+%if "%{python_flavor}" == "python36"
+BuildRequires:  python3-dataclasses
+%endif
 Requires:       python3-requests
+%if "%{python_flavor}" == "python36"
+Requires:       python3-dataclasses
+%endif
 
 %description
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+dataclasses~=0.8; python_version < '3.7'

--- a/tests/data/test.config
+++ b/tests/data/test.config
@@ -1,0 +1,3 @@
+regions:
+  aws:
+    - zu-west-1

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -35,11 +35,42 @@ def test_get_all_regions():
         'sa-east-1',
         'us-east-1', 'us-east-2',
         'us-west-1', 'us-west-2',
+        'zu-west-1',
         'cn-north-1',
         'cn-northwest-1',
         'us-gov-east-1',
         'us-gov-west-1'
     ]
 
-    regions = get_all_regions()
+    regions = get_all_regions(config_file='tests/data/test.config')
+    assert regions == expected_regions
+
+
+@vcr.use_cassette(
+    'tests/cassettes/get_all_regions.yml',
+    before_record_response=scrub_headers()
+)
+def test_get_all_regions_no_config():
+    expected_regions = [
+        'af-south-1',
+        'ap-east-1',
+        'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3',
+        'ap-south-1',
+        'ap-southeast-1', 'ap-southeast-2',
+        'ca-central-1',
+        'eu-central-1',
+        'eu-north-1',
+        'eu-south-1',
+        'eu-west-1', 'eu-west-2', 'eu-west-3',
+        'me-south-1',
+        'sa-east-1',
+        'us-east-1', 'us-east-2',
+        'us-west-1', 'us-west-2',
+        'cn-north-1',
+        'cn-northwest-1',
+        'us-gov-east-1',
+        'us-gov-west-1'
+    ]
+
+    regions = get_all_regions(config_file='tests/data/no.config')
     assert regions == expected_regions


### PR DESCRIPTION
This allow custom regions to be added to either of the partitions. The format of the config file is as follows:

```yaml
regions:
  aws:
    - new-region-1
  aws_cn:
    - new-cn-region
  aws_us_gov:
    - new-gov-region
````